### PR TITLE
Add very simple filesize check

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -4,4 +4,12 @@ database="database-name-here"
 backupDir="/tmp"
 filename="$backupDir/backup-$(date +%Y-%m-%d).gz"
 pg_dump $database | gzip > $filename
-curl -H "Authorization: Bearer $token" https://api-content.dropbox.com/1/files_put/auto/ -T $filename && rm $filename || echo 'Curl returned error:'$?
+
+bytes_to_send=$( du -b $filename | cut -f1 )
+bytes_dropbox_received=$(curl -sH "Authorization: Bearer $token"  https://api-content.dropbox.com/1/files_put/auto/ -T $filename | sed -r 's@^.* "bytes": ([0-9]+).*$@\1@')
+
+if [ $bytes_to_send != $bytes_dropbox_received ]; then
+  echo 'ERROR: Bytes sent/received mismatch!' # mail would be nice here
+else
+  rm $filename
+fi


### PR DESCRIPTION
Since dropbox doesn't provide any sort of checksum metadata (MD5, SHA1, etc) through API after the file has been uploaded, do a very simple filesize check before deleting the backup file